### PR TITLE
feat: add hyperlinks to blogs

### DIFF
--- a/list.md
+++ b/list.md
@@ -16,190 +16,190 @@ Finally, to speed up your system by 200%, just run the following command: "sudo 
 
 ### Linux
 
-- @linux-real (Just Linux)
+- [@linux-real](https://www.tumblr.com/linux-real) (Just Linux)
 
 ### The Distro Blogs
 
-- @alpine-official (UwU bc smol)
-- @arch-official
+- [@alpine-official](https://www.tumblr.com/alpine-official) (UwU bc smol)
+- [@arch-official](https://www.tumblr.com/arch-official)
 - used by @arch-user
-- @artix-linux-official (Constantly says they're better than arch, while mainly replacing only the init)
-- @centos-official
-- @chromeos-official (Your school says hi)
-- @debian-official
-- @devuan-official (Artix but with Debian instead of arch)
-- @endeavouros-official
-- @fedora-official (Linux with a hat)
-- @garuda-official
-- @gentoo-official (tougher arch)
-  - @evil-gentoo
-- @haiku-official
-- @hannah-montana-linux-official
-- @kali-official ("I'm a gamer")
-- @lfs-official (the hardest distro challenge)
-- @linuxmint-official (Linux for people with a life)
-  - @mint-offical (someone didn't read the list)
-- @manjaro-official (Arch with less steps)
-- @microos-official (Smol suse?)
-- @nixos-official (thinks that your config should be a special snowflake of a file)
-- @openmediavault-official (Your Files)
-- @opensuse-official (Happy lil gecko)
-- @parrotos-official
-- @pinkos-official
-- @pisslinux-official (tell me this isnt a real distro pls)
-- @popos-official (Mint again? Oh, it has more updates.)
-- @porteusofficial (Portable, crazy, son of slackware)
-- @puppylinux-official (Awww, puppy!)
-- @q4os-tde-official
-- @qubesos-official
-- @raspbian-official
-- @redstar-official (control of information meets linux) (hard mode)
-- @retropieos-official (Raspbian's sister... I think?)
-- @rhel-official (a murderer and sellout)
-- @rocky-linux-official (Rhel, without the bad parts)
-- @slackware-official (Slack? Where?!)
-- @solus-official (est. 2025-03-19)
-- @steamos-official (me, I help with gaming)
-- @tailsos-official (Fits in any bag like a puppy and will assist you with hiding from the fbi)
-- @tophatlinux-official (the best hat-based distro)
-- @ubuntu-official (thinks GNOME is good for some reason)
-  - @evil-ubuntu
-- @uwuntu-official (Ubuntu.... and the rest is in the name)
-- @vanillaos-official
-- @void-linux-official (Honestly, I don't even know.)
-  - @void-linux-musl (great, now I'm more confused)
-- @wubuntu-officially-unofficial
-- @yiffos-official
-- @zorin-os-official (the only distro that starts with Z)
+- [@artix-linux-official](https://www.tumblr.com/artix-linux-official) (Constantly says they're better than arch, while mainly replacing only the init)
+- [@centos-official](https://www.tumblr.com/centos-official)
+- [@chromeos-official](https://www.tumblr.com/chromeos-official) (Your school says hi)
+- [@debian-official](https://www.tumblr.com/debian-official)
+- [@devuan-official](https://www.tumblr.com/devuan-official) (Artix but with Debian instead of arch)
+- [@endeavouros-official](https://www.tumblr.com/endeavouros-official)
+- [@fedora-official](https://www.tumblr.com/fedora-official) (Linux with a hat)
+- [@garuda-official](https://www.tumblr.com/garuda-official)
+- [@gentoo-official](https://www.tumblr.com/gentoo-official) (tougher arch)
+  - [@evil-gentoo](https://www.tumblr.com/evil-gentoo)
+- [@haiku-official](https://www.tumblr.com/haiku-official)
+- [@hannah-montana-linux-official](https://www.tumblr.com/hannah-montana-linux-official)
+- [@kali-official](https://www.tumblr.com/kali-official) ("I'm a gamer")
+- [@lfs-official](https://www.tumblr.com/lfs-official) (the hardest distro challenge)
+- [@linuxmint-official](https://www.tumblr.com/linuxmint-official) (Linux for people with a life)
+  - [@mint-offical](https://www.tumblr.com/mint-offical) (someone didn't read the list)
+- [@manjaro-official](https://www.tumblr.com/manjaro-official) (Arch with less steps)
+- [@microos-official](https://www.tumblr.com/microos-official) (Smol suse?)
+- [@nixos-official](https://www.tumblr.com/nixos-official) (thinks that your config should be a special snowflake of a file)
+- [@openmediavault-official](https://www.tumblr.com/openmediavault-official) (Your Files)
+- [@opensuse-official](https://www.tumblr.com/opensuse-official) (Happy lil gecko)
+- [@parrotos-official](https://www.tumblr.com/parrotos-official)
+- [@pinkos-official](https://www.tumblr.com/pinkos-official)
+- [@pisslinux-official](https://www.tumblr.com/pisslinux-official) (tell me this isnt a real distro pls)
+- [@popos-official](https://www.tumblr.com/popos-official) (Mint again? Oh, it has more updates.)
+- [@porteusofficial](https://www.tumblr.com/porteusofficial) (Portable, crazy, son of slackware)
+- [@puppylinux-official](https://www.tumblr.com/puppylinux-official) (Awww, puppy!)
+- [@q4os-tde-official](https://www.tumblr.com/q4os-tde-official)
+- [@qubesos-official](https://www.tumblr.com/qubesos-official)
+- [@raspbian-official](https://www.tumblr.com/raspbian-official)
+- [@redstar-official](https://www.tumblr.com/redstar-official) (control of information meets linux) (hard mode)
+- [@retropieos-official](https://www.tumblr.com/retropieos-official) (Raspbian's sister... I think?)
+- [@rhel-official](https://www.tumblr.com/rhel-official) (a murderer and sellout)
+- [@rocky-linux-official](https://www.tumblr.com/rocky-linux-official) (Rhel, without the bad parts)
+- [@slackware-official](https://www.tumblr.com/slackware-official) (Slack? Where?!)
+- [@solus-official](https://www.tumblr.com/solus-official) (est. 2025-03-19)
+- [@steamos-official](https://www.tumblr.com/steamos-official) (me, I help with gaming)
+- [@tailsos-official](https://www.tumblr.com/tailsos-official) (Fits in any bag like a puppy and will assist you with hiding from the fbi)
+- [@tophatlinux-official](https://www.tumblr.com/tophatlinux-official) (the best hat-based distro)
+- [@ubuntu-official](https://www.tumblr.com/ubuntu-official) (thinks GNOME is good for some reason)
+  - [@evil-ubuntu](https://www.tumblr.com/evil-ubuntu)
+- [@uwuntu-official](https://www.tumblr.com/uwuntu-official) (Ubuntu.... and the rest is in the name)
+- [@vanillaos-official](https://www.tumblr.com/vanillaos-official)
+- [@void-linux-official](https://www.tumblr.com/void-linux-official) (Honestly, I don't even know.)
+  - [@void-linux-musl](https://www.tumblr.com/void-linux-musl) (great, now I'm more confused)
+- [@wubuntu-officially-unofficial](https://www.tumblr.com/wubuntu-officially-unofficial)
+- [@yiffos-official](https://www.tumblr.com/yiffos-official)
+- [@zorin-os-official](https://www.tumblr.com/zorin-os-official) (the only distro that starts with Z)
 
 ### The Software Blogs
 
-- @ansible-official (IT management tool) (I think?)
-- @cinnamon-official
-- @cool-retro-term-official (Terminal Emulator)
-- @cosmic-official (New Wayland Compositor)
-- @cups-official
-- @budgie-desktop (est. 2025-01-05)
-- @docker-official (containerization)
-- @dwm-official (formerly @blackarch-official)
-- @emacs-official (the ultimate editor)
-  - @emacs-evil-mode
-- @mozilla-firefox
-- @ffmpegofficial (everyone makes a 🫃 joke for some reason)
-- @fish-shell (Shell with built-in autocomplete but non POSIX)
-- @flatpak-official
-- @gcc-official
-- @git-official
-- @glsl-official
-- @gnome-de-official
-  - @gnome-terminal-official
-- @gnu-imp-official (The GNU Image Manipulation Program)
-- @gnu-nano-official (Text for the weak)
-- @helix-editor (vim but backwards)
-- @hyprland-official (Wayland Compositor)
-- @i3-official (Window Manager)
-- @icecat-official (firefox fork)
-- @inkscape-official (est. 2024-04-02)
-- @kde-official | Creator of everything beginning with 'K'...
-  - @kde-plasma-official (best DE/Compositor)
-  - @krita-unofficial
-- @kitty-terminal-official (est. 2025-02-08)
-- @kubernetes-official (Docker's friend and Kate's hideout)
-- @learn-coq-official
-- @lunati-official (NOT Minecraft)
-- @neofetch-official
-- @networkmanager-official
-- @packagemanager-official
-- @powershell-official
-- @river-official
-- @steamvr-official (est. 2025-04-25)
-- @systemdeez (arguably systemd) (the startup daemon)
-- @neovim-official (your favorite text editor)
-- @sway-official (the tree blows in wayland to i3)
-- @sed-official (`s/[RrLl]/w/g`)
-- @truenas-official
-- @vi-official
-- @vim-official
-- @vlc-official
-- @vorapis-v3-official (youtube frontend?)
-- @vulcan-official (performance is a must)
-- @wayfire-official
-- @x11-official
-- @xfce4-official
-- @xfwm-official
-- @xorg-official
-- @xmonad-official
+- [@ansible-official](https://www.tumblr.com/ansible-official) (IT management tool) (I think?)
+- [@cinnamon-official](https://www.tumblr.com/cinnamon-official)
+- [@cool-retro-term-official](https://www.tumblr.com/cool-retro-term-official) (Terminal Emulator)
+- [@cosmic-official](https://www.tumblr.com/cosmic-official) (New Wayland Compositor)
+- [@cups-official](https://www.tumblr.com/cups-official)
+- [@budgie-desktop](https://www.tumblr.com/budgie-desktop) (est. 2025-01-05)
+- [@docker-official](https://www.tumblr.com/docker-official) (containerization)
+- [@dwm-official](https://www.tumblr.com/dwm-official) (formerly @blackarch-official)
+- [@emacs-official](https://www.tumblr.com/emacs-official) (the ultimate editor)
+  - [@emacs-evil-mode](https://www.tumblr.com/emacs-evil-mode)
+- [@mozilla-firefox](https://www.tumblr.com/mozilla-firefox)
+- [@ffmpegofficial](https://www.tumblr.com/ffmpegofficial) (everyone makes a 🫃 joke for some reason)
+- [@fish-shell](https://www.tumblr.com/fish-shell) (Shell with built-in autocomplete but non POSIX)
+- [@flatpak-official](https://www.tumblr.com/flatpak-official)
+- [@gcc-official](https://www.tumblr.com/gcc-official)
+- [@git-official](https://www.tumblr.com/git-official)
+- [@glsl-official](https://www.tumblr.com/glsl-official)
+- [@gnome-de-official](https://www.tumblr.com/gnome-de-official)
+  - [@gnome-terminal-official](https://www.tumblr.com/gnome-terminal-official)
+- [@gnu-imp-official](https://www.tumblr.com/gnu-imp-official) (The GNU Image Manipulation Program)
+- [@gnu-nano-official](https://www.tumblr.com/gnu-nano-official) (Text for the weak)
+- [@helix-editor](https://www.tumblr.com/helix-editor) (vim but backwards)
+- [@hyprland-official](https://www.tumblr.com/hyprland-official) (Wayland Compositor)
+- [@i3-official](https://www.tumblr.com/i3-official) (Window Manager)
+- [@icecat-official](https://www.tumblr.com/icecat-official) (firefox fork)
+- [@inkscape-official](https://www.tumblr.com/inkscape-official) (est. 2024-04-02)
+- [@kde-official](https://www.tumblr.com/kde-official) | Creator of everything beginning with 'K'...
+  - [@kde-plasma-official](https://www.tumblr.com/kde-plasma-official) (best DE/Compositor)
+  - [@krita-unofficial](https://www.tumblr.com/krita-unofficial)
+- [@kitty-terminal-official](https://www.tumblr.com/kitty-terminal-official) (est. 2025-02-08)
+- [@kubernetes-official](https://www.tumblr.com/kubernetes-official) (Docker's friend and Kate's hideout)
+- [@learn-coq-official](https://www.tumblr.com/learn-coq-official)
+- [@lunati-official](https://www.tumblr.com/lunati-official) (NOT Minecraft)
+- [@neofetch-official](https://www.tumblr.com/neofetch-official)
+- [@networkmanager-official](https://www.tumblr.com/networkmanager-official)
+- [@packagemanager-official](https://www.tumblr.com/packagemanager-official)
+- [@powershell-official](https://www.tumblr.com/powershell-official)
+- [@river-official](https://www.tumblr.com/river-official)
+- [@steamvr-official](https://www.tumblr.com/steamvr-official) (est. 2025-04-25)
+- [@systemdeez](https://www.tumblr.com/systemdeez) (arguably systemd) (the startup daemon)
+- [@neovim-official](https://www.tumblr.com/neovim-official) (your favorite text editor)
+- [@sway-official](https://www.tumblr.com/sway-official) (the tree blows in wayland to i3)
+- [@sed-official](https://www.tumblr.com/sed-official) (`s/[RrLl]/w/g`)
+- [@truenas-official](https://www.tumblr.com/truenas-official)
+- [@vi-official](https://www.tumblr.com/vi-official)
+- [@vim-official](https://www.tumblr.com/vim-official)
+- [@vlc-official](https://www.tumblr.com/vlc-official)
+- [@vorapis-v3-official](https://www.tumblr.com/vorapis-v3-official) (youtube frontend?)
+- [@vulcan-official](https://www.tumblr.com/vulcan-official) (performance is a must)
+- [@wayfire-official](https://www.tumblr.com/wayfire-official)
+- [@x11-official](https://www.tumblr.com/x11-official)
+- [@xfce4-official](https://www.tumblr.com/xfce4-official)
+- [@xfwm-official](https://www.tumblr.com/xfwm-official)
+- [@xorg-official](https://www.tumblr.com/xorg-official)
+- [@xmonad-official](https://www.tumblr.com/xmonad-official)
 
 ### Programming Languages
 
-- @assembly-official
-- @brainfuck-official
-- @c-official
-- @csharp-official
-- @css-official §
-- @gdscript-official
-- @haskell-official
-- @java-official
-- @javascript-official
-  - @official-js
-- @malbolge-official
-- @metagolfscript-official
-- @nios2-asm (I don't know if this belongs here, but whatever)
-- @perl-official
-- @powershell-official
-- @puredata-official
-- @python-official
-- @riskv-official
-- @rust-official
-  - @rust-analyzer-official
+- [@assembly-official](https://www.tumblr.com/assembly-official)
+- [@brainfuck-official](https://www.tumblr.com/brainfuck-official)
+- [@c-official](https://www.tumblr.com/c-official)
+- [@csharp-official](https://www.tumblr.com/csharp-official)
+- [@css-official](https://www.tumblr.com/css-official) §
+- [@gdscript-official](https://www.tumblr.com/gdscript-official)
+- [@haskell-official](https://www.tumblr.com/haskell-official)
+- [@java-official](https://www.tumblr.com/java-official)
+- [@javascript-official](https://www.tumblr.com/javascript-official)
+  - [@official-js](https://www.tumblr.com/official-js)
+- [@malbolge-official](https://www.tumblr.com/malbolge-official)
+- [@metagolfscript-official](https://www.tumblr.com/metagolfscript-official)
+- [@nios2-asm](https://www.tumblr.com/nios2-asm) (I don't know if this belongs here, but whatever)
+- [@perl-official](https://www.tumblr.com/perl-official)
+- [@powershell-official](https://www.tumblr.com/powershell-official)
+- [@puredata-official](https://www.tumblr.com/puredata-official)
+- [@python-official](https://www.tumblr.com/python-official)
+- [@riskv-official](https://www.tumblr.com/riskv-official)
+- [@rust-official](https://www.tumblr.com/rust-official)
+  - [@rust-analyzer-official](https://www.tumblr.com/rust-analyzer-official)
 
 ### Other*
 
 #### themes
 
-- @catppuccin-frappe-official (est. 2025-03-25)
-- @catppuccin-latte-official
-- @catppuccin-macchiato-official
-- @catppuccin-mocha-official
-- @gruvbox-official
+- [@catppuccin-frappe-official](https://www.tumblr.com/catppuccin-frappe-official) (est. 2025-03-25)
+- [@catppuccin-latte-official](https://www.tumblr.com/catppuccin-latte-official)
+- [@catppuccin-macchiato-official](https://www.tumblr.com/catppuccin-macchiato-official)
+- [@catppuccin-mocha-official](https://www.tumblr.com/catppuccin-mocha-official)
+- [@gruvbox-official](https://www.tumblr.com/gruvbox-official)
 
 #### mascots
 
-- @tux-official (See also: Gentoo Penguin)
-- @xenia-the-fox (The true mascot)
+- [@tux-official](https://www.tumblr.com/tux-official) (See also: Gentoo Penguin)
+- [@xenia-the-fox](https://www.tumblr.com/xenia-the-fox) (The true mascot)
 
 #### idk
 
-- @distrochooser (Which distro should I pick?)
-- @i-suggest-linux (better than most i-suggest blogs)
+- [@distrochooser](https://www.tumblr.com/distrochooser) (Which distro should I pick?)
+- [@i-suggest-linux](https://www.tumblr.com/i-suggest-linux) (better than most i-suggest blogs)
 
 ### Computers/Hardware
 
-- @framework-official (The apple of Linux laptops, except repairable)
-- @gpu-official (your GPU)
-- @lenovo-real (Makes people happy with think pads)
-- @vax-official
+- [@framework-official](https://www.tumblr.com/framework-official) (The apple of Linux laptops, except repairable)
+- [@gpu-official](https://www.tumblr.com/gpu-official) (your GPU)
+- [@lenovo-real](https://www.tumblr.com/lenovo-real) (Makes people happy with think pads)
+- [@vax-official](https://www.tumblr.com/vax-official)
 
 ### Non Linux Blogs
 
-- @iglunix-official § (affiliated with the project, too!)
-- @minix-official
-- @netbsd-official (the toaster is alive!)
-- @openbsd-official (est. 2025-02-17)
-- @windowsxp-official
-- @windows-7-official (The last good version of windows)
-- @windows10-official
-- @windows11-official
-- @zipp-os-official (another "better os" project)
+- [@iglunix-official](https://www.tumblr.com/iglunix-official) § (affiliated with the project, too!)
+- [@minix-official](https://www.tumblr.com/minix-official)
+- [@netbsd-official](https://www.tumblr.com/netbsd-official) (the toaster is alive!)
+- [@openbsd-official](https://www.tumblr.com/openbsd-official) (est. 2025-02-17)
+- [@windowsxp-official](https://www.tumblr.com/windowsxp-official)
+- [@windows-7-official](https://www.tumblr.com/windows-7-official) (The last good version of windows)
+- [@windows10-official](https://www.tumblr.com/windows10-official)
+- [@windows11-official](https://www.tumblr.com/windows11-official)
+- [@zipp-os-official](https://www.tumblr.com/zipp-os-official) (another "better os" project)
 
 ### Non Official Blogs†
 
-- @forever-stuck-on-java-8
-- @greekie-via-linux
-- @mipseb
-- @monaddecepticon (does a cool rice review thing)
-- @the-pink-hacker
-- @robynthelinuxuser
+- [@forever-stuck-on-java-8](https://www.tumblr.com/forever-stuck-on-java-8)
+- [@greekie-via-linux](https://www.tumblr.com/greekie-via-linux)
+- [@mipseb](https://www.tumblr.com/mipseb)
+- [@monaddecepticon](https://www.tumblr.com/monaddecepticon) (does a cool rice review thing)
+- [@the-pink-hacker](https://www.tumblr.com/the-pink-hacker)
+- [@robynthelinuxuser](https://www.tumblr.com/robynthelinuxuser)
 
 ### Open Blog Opportunities
 


### PR DESCRIPTION
Adding hyperlinks to the tumblr blogs.

Was achieved using `sed -E 's/^(\ *-\ )@([a-zA-Z0-9_-]+)/\1[@\2](https:\/\/www.tumblr.com\/\2)/' list.md -i`

I tested a few random samples, and the links appear to be working correctly.